### PR TITLE
Fix missing include

### DIFF
--- a/xsensmt/XsensMT.cpp
+++ b/xsensmt/XsensMT.cpp
@@ -15,7 +15,7 @@
 #include <chrono>
 #include <iostream>
 #include <string>
-#include<functional>
+#include <functional>
 
 #include <xcommunication/int_xsdatapacket.h>
 #include <xcommunication/legacydatapacket.h>

--- a/xsensmt/XsensMT.cpp
+++ b/xsensmt/XsensMT.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <iostream>
 #include <string>
+#include<functional>
 
 #include <xcommunication/int_xsdatapacket.h>
 #include <xcommunication/legacydatapacket.h>


### PR DESCRIPTION
Following https://github.com/robotology-playground/xsensmt-yarp-driver/issues/14, I added the `#include<functional>`  to the file `XsensMT.cpp` in order to fix the compilation on Ubuntu 18.04. 